### PR TITLE
Do not force current time on 'editevent' request

### DIFF
--- a/lib/livejournal/entry.rb
+++ b/lib/livejournal/entry.rb
@@ -80,7 +80,6 @@ module LiveJournal
       @preformatted = false
       @backdated = false
       @comments = :normal
-      @time = Time.now
       @security = :public
       @allowmask = nil
       @screening = :default
@@ -237,9 +236,15 @@ module LiveJournal
 
       req['give_features']  = self.give_features ? 1 : 0
 
-      req['year'], req['mon'], req['day'] = 
-        self.time.year, self.time.mon, self.time.day
-      req['hour'], req['min'] = self.time.hour, self.time.min
+      if req['mode'] == 'postevent' && self.time.nil?
+        self.time = Time.now.gmtime
+      end
+
+      if self.time
+        req['year'], req['mon'], req['day'] =
+            self.time.year, self.time.mon, self.time.day
+        req['hour'], req['min'] = self.time.hour, self.time.min
+      end
 
       { 'current_mood' => self.mood,
         'current_moodid' => self.moodid,


### PR DESCRIPTION
The date and time arguments (year, mon, day, hour, min) are not actually required on [editevent](http://www.livejournal.com/doc/server/ljp.csp.xml-rpc.editevent.html) request. They should only be set if changed. 

But the current implementation forces sending the current date and time with `editevent`. If I want to update an old entry it pops up as the most recent one.

My patch allows the client not to send date and time arguments with `editevent`. Of course, if `entry.time` is set explicitly it is sent. And `postevent` sends current time by default as before.
